### PR TITLE
Fix typo in quick reference

### DIFF
--- a/docs/quick_reference.html
+++ b/docs/quick_reference.html
@@ -1100,7 +1100,7 @@
                 <h3>Notes</h3>
                 <ul>
                   <li>Create generic borders using <code>.bordered</code></li>
-                  <li>Rounded and circular border radii available using <code>.rounded</code> and <code>.ciruclar</code> classes</li>
+                  <li>Rounded and circular border radii available using <code>.rounded</code> and <code>.circular</code> classes</li>
                   <li>Generic shadows available using the <code>.shadow-small</code>, <code>.shadow-medium</code>, <code>.shadow-large</code> and <code>.shadow-none</code> classes</li>
                   <li>Combine generic borders, border radii and generic shadows with each other but not with themselves</li>
                   <li>All classes use <code><span class="fore-secondary">!important</span></code> declarations</li>


### PR DESCRIPTION
`.ciruclar` → `.circular` at the second bulletpoint of "Generic borders & shadows" at https://chalarangelo.github.io/mini.css/quick_reference.html