### PR TITLE
fix background styles for select in Safari

### DIFF
--- a/src/mini/_input_control.scss
+++ b/src/mini/_input_control.scss
@@ -166,6 +166,13 @@ legend {
 textarea {
 	overflow: auto;
 }
+// Correct background styling in Safari
+select {
+	background: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0Ljk1IDEwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2ZmZjt9LmNscy0ye2ZpbGw6IzQ0NDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPmFycm93czwvdGl0bGU+PHJlY3QgY2xhc3M9ImNscy0xIiB3aWR0aD0iNC45NSIgaGVpZ2h0PSIxMCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSIxLjQxIDQuNjcgMi40OCAzLjE4IDMuNTQgNC42NyAxLjQxIDQuNjciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMy41NCA1LjMzIDIuNDggNi44MiAxLjQxIDUuMzMgMy41NCA1LjMzIi8+PC9zdmc+) no-repeat 95% 50%;
+	-moz-appearance: none;
+	-webkit-appearance: none;
+	appearance: none;
+}
 // Correct style in Chrome and Safari.
 [type="search"] {
 	-webkit-appearance: textfield;

--- a/src/mini/_input_control.scss
+++ b/src/mini/_input_control.scss
@@ -111,8 +111,8 @@ legend {
 				// New syntax
 				-webkit-flex-grow: 1;
 								flex-grow: 1;
-				-webkit-flex-basis: 0;
-								flex-basis: 0;
+				-webkit-flex-basis: 0px;
+								flex-basis: 0px;
 			}
 		}
 	}
@@ -153,8 +153,8 @@ legend {
 			// New syntax
 			-webkit-flex-grow: 1;
 							flex-grow: 1;
-			-webkit-flex-basis: 0;
-							flex-basis: 0;
+			-webkit-flex-basis: 0px;
+							flex-basis: 0px;
 		}
 	}
 }

--- a/src/mini/_input_control.scss
+++ b/src/mini/_input_control.scss
@@ -111,8 +111,8 @@ legend {
 				// New syntax
 				-webkit-flex-grow: 1;
 								flex-grow: 1;
-				-webkit-flex-basis: 0px;
-								flex-basis: 0px;
+				-webkit-flex-basis: 0;
+								flex-basis: 0;
 			}
 		}
 	}
@@ -153,8 +153,8 @@ legend {
 			// New syntax
 			-webkit-flex-grow: 1;
 							flex-grow: 1;
-			-webkit-flex-basis: 0px;
-							flex-basis: 0px;
+			-webkit-flex-basis: 0;
+							flex-basis: 0;
 		}
 	}
 }


### PR DESCRIPTION
Fixed issue #80 where the styling in Safari for `select` weren't working properly.

_Only_ adding `-webkit-appearance: none` won't suffice since it not only removes the gloss in Safari, but also removes the arrows. 

Here's a screenshot with this fix in both Chrome & Safari:

**Safari**
![safari](https://user-images.githubusercontent.com/2086896/27258808-072ce31e-53ca-11e7-83d8-db99e347e3ed.png)

**Chrome**
![chrome](https://user-images.githubusercontent.com/2086896/27258807-072c3f90-53ca-11e7-81bf-d6f90a123c77.png)