### PR TITLE
fix unitless flex-basis bug on some older devices

### DIFF
--- a/src/mini/_input_control.scss
+++ b/src/mini/_input_control.scss
@@ -111,8 +111,8 @@ legend {
 				// New syntax
 				-webkit-flex-grow: 1;
 								flex-grow: 1;
-				-webkit-flex-basis: 0;
-								flex-basis: 0;
+				-webkit-flex-basis: 0px;
+								flex-basis: 0px;
 			}
 		}
 	}
@@ -153,8 +153,8 @@ legend {
 			// New syntax
 			-webkit-flex-grow: 1;
 							flex-grow: 1;
-			-webkit-flex-basis: 0;
-							flex-basis: 0;
+			-webkit-flex-basis: 0px;
+							flex-basis: 0px;
 		}
 	}
 }


### PR DESCRIPTION
Fix issue #81 where `flex-basis: 0` is unitless and interpreted as a syntax error.

> If the <preferred-size> is ‘0’, it must be specified with a unit (like ‘0px’) to avoid ambiguity; unitless zero will either be interpreted as as one of the flexibilities, or is a syntax error.
>
> _[W3C - CSS Flexible Box Layout Module](https://www.w3.org/TR/2012/WD-css3-flexbox-20120322/#flex)_

Screenshot using Samsung Galaxy S5:

![samsung](https://user-images.githubusercontent.com/2086896/27260317-9a965350-53ee-11e7-8c5e-ca321afce6f9.png)

One potential problem with this solution is minification. Most minifiers will change `0px -> 0`. I've already tried using `0%`, but that didn't work.