### PR TITLE
wrong var for webkit progress bar background

### DIFF
--- a/src/mini/_progress.scss
+++ b/src/mini/_progress.scss
@@ -67,7 +67,7 @@ progress {
   }
   // Background color on webkit browser
   &::-webkit-progress-bar {
-    background: var(#{$progress-back-color});
+    background: var(#{$progress-back-color-var});
   }
   // Foreground color on Firefox
   &::-moz-progress-bar {


### PR DESCRIPTION
for mini.css v3.0.0
changed $progress-back-color to $progress-back-color-var