### PR TITLE
Fix calculation syntax for some utilities

### DIFF
--- a/src/mini/_utility_mixins.scss
+++ b/src/mini/_utility_mixins.scss
@@ -120,24 +120,24 @@
   $hidden-large-suffix : 'lg', $hidden-use-four-step-grid : false,
   $hidden-small-breakpoint : 480px, $hidden-extra-small-suffix : 'xs') {
   @if $hidden-use-four-step-grid {
-    @media screen and (max-width: #{$hidden-small-breakpoint}-1px) {
+    @media screen and (max-width: $hidden-small-breakpoint - 1px) {
       .#{$hidden-prefix}-#{$hidden-extra-small-suffix} {
         display: none !important;
       }
     }
-    @media screen and (min-width: #{$hidden-small-breakpoint}) and (max-width: #{$hidden-medium-breakpoint}-1px) {
+    @media screen and (min-width: #{$hidden-small-breakpoint}) and (max-width: $hidden-medium-breakpoint - 1px) {
       .#{$hidden-prefix}-#{$hidden-small-suffix} {
         display: none !important;
       }
     }
   }
   @else {
-    @media screen and (max-width: #{$hidden-medium-breakpoint}-1px) {
+    @media screen and (max-width: $hidden-medium-breakpoint - 1px) {
       .#{$hidden-prefix}-#{$hidden-small-suffix} {
         display: none !important;
       }
     }
-    @media screen and (min-width: #{$hidden-medium-breakpoint}) and (max-width: #{$hidden-large-breakpoint}-1px) {
+    @media screen and (min-width: #{$hidden-medium-breakpoint}) and (max-width: $hidden-large-breakpoint - 1px) {
       .#{$hidden-prefix}-#{$hidden-medium-suffix} {
         display: none !important;
       }
@@ -165,7 +165,7 @@
   $visually-hidden-large-suffix : 'lg', $visually-hidden-use-four-step-grid : false,
   $visually-hidden-small-breakpoint : 480px, $visually-hidden-extra-small-suffix : 'xs') {
   @if $visually-hidden-use-four-step-grid {
-    @media screen and (max-width: #{$visually-hidden-small-breakpoint}-1px) {
+    @media screen and (max-width: $visually-hidden-small-breakpoint - 1px) {
       .#{$visually-hidden-prefix}-#{$visually-hidden-extra-small-suffix} {
         position: absolute !important;
         width: 1px !important;
@@ -179,7 +179,7 @@
         overflow: hidden !important;
       }
     }
-    @media screen and (min-width: #{$visually-hidden-small-breakpoint}) and (max-width: #{$visually-hidden-medium-breakpoint}-1px) {
+    @media screen and (min-width: #{$visually-hidden-small-breakpoint}) and (max-width: $visually-hidden-medium-breakpoint - 1px) {
       .#{$visually-hidden-prefix}-#{$visually-hidden-small-suffix} {
         position: absolute !important;
         width: 1px !important;
@@ -195,7 +195,7 @@
     }
   }
   @else {
-    @media screen and (max-width: #{$visually-hidden-medium-breakpoint}-1px) {
+    @media screen and (max-width: $visually-hidden-medium-breakpoint - 1px) {
       .#{$visually-hidden-prefix}-#{$visually-hidden-small-suffix} {
         position: absolute !important;
         width: 1px !important;
@@ -209,7 +209,7 @@
         overflow: hidden !important;
       }
     }
-    @media screen and (min-width: #{$visually-hidden-medium-breakpoint}) and (max-width: #{$visually-hidden-large-breakpoint}-1px) {
+    @media screen and (min-width: #{$visually-hidden-medium-breakpoint}) and (max-width: $visually-hidden-large-breakpoint - 1px) {
       .#{$visually-hidden-prefix}-#{$visually-hidden-medium-suffix} {
         position: absolute !important;
         width: 1px !important;


### PR DESCRIPTION
Hi,

I stumbled upon the following SCSS example:

```scss
$var: 20px;

// Case 1
@media (max-width: #{$var} - 1px) {
  body { font-size: #{$var} - 1px; }
}
// Case 2
@media (max-width: #{$var - 1px}) {
  body { font-size: #{$var - 1px}; }
}
// Case 3
@media (max-width: $var - 1px) {
  body { font-size: $var - 1px; }
}
```

When compiled (try this [online tool](https://www.sassmeister.com/)), the calculation is only done in the second and third case. The output from the first case includes `- 1px` in the output, which is not valid CSS?

I replaced a few occurencies of the first case. Did this break the affected helpers?
