### PR TITLE
Arrows of tooltips use the --tooltip-back-color variable

### DIFF
--- a/src/mini/_contextual.scss
+++ b/src/mini/_contextual.scss
@@ -161,10 +161,10 @@ mark {
       left: calc(50% - var(#{$universal-margin-var}));
     }
     &:not(.#{$tooltip-bottom-name}):before { // Top (default) tooltip styling
-      border-top-color: $tooltip-back-color;
+      border-top-color: var(#{$tooltip-back-color-var});
     }
     &.#{$tooltip-bottom-name}:before { // Bottom tooltip styling
-      border-bottom-color: $tooltip-back-color;
+      border-bottom-color: var(#{$tooltip-back-color-var});
     }
     &:after {  // This is the actual tooltip's text block
       content: attr(aria-label);


### PR DESCRIPTION
Background color for tooltips can be changed by changing the value of the --tooltip-back-color variable : arrows of tooltips use too this variable now
![tooltip-arrow-color](https://user-images.githubusercontent.com/46624375/65816789-68f0ce00-e200-11e9-8443-4b2b8c5a78a6.png)
