### PR TITLE
Add span separator to header.

### DIFF
--- a/src/mini/_navigation.scss
+++ b/src/mini/_navigation.scss
@@ -126,8 +126,8 @@ header {
     padding: var(#{$universal-padding-var}) calc(2 * var(#{$universal-padding-var}));
     text-decoration: none;
   }
-  // Link styling.
-  button, [type="button"], .#{$button-class-name}, [role="button"] {
+  // Link and span styling.
+  span, button, [type="button"], .#{$button-class-name}, [role="button"] {
     box-sizing: border-box;
     position: relative;
     top: calc(0rem - var(#{$universal-padding-var}) / 4);  // Use universal-padding to offset the padding of the header.
@@ -142,7 +142,9 @@ header {
     @if $_header-links-uppercase {
       text-transform: uppercase;
     }
-    &:hover, &:focus {
+  }
+  button, [type="button"], .#{$button-class-name}, [role="button"] {
+   &:hover, &:focus {
       background: var(#{$header-hover-back-color-var});
     }
   }


### PR DESCRIPTION
Currently the header only supports links and nothing else. This adds spans which don't have a hover state but otherwise look identical to links.

If there's a better way to do this please let me know.

This is my current use case. The `<span>|</span>` is used as a separator.
```html
<header class="sticky">
	<a href="/" class="logo router-link-active">
		<span class="icon-key inverse"></span>
	</a>
	<a href="/" class="button router-link-active">Home</a>
	<a href="/search" class="button router-link-exact-active router-link-active">Search</a>
	<span>|</span>
	<a href="/admin" class="button router-link-exact-active router-link-active">Admin tools</a>
</header>
```